### PR TITLE
Update posts.js

### DIFF
--- a/MabiCommerce/data/db/posts.js
+++ b/MabiCommerce/data/db/posts.js
@@ -101,7 +101,7 @@
         "Image": "data/img/item/wool_boots.png",
         "Weight": 8,
         "QuantityPerSlot": 10,
-        "MerchantRating": 2,
+        "MerchantRating": 1,
         "MultiFactor": 1.15,
         "AddFactor": 18.05,
       },


### PR DESCRIPTION
![dunby merchant rating](https://cloud.githubusercontent.com/assets/4476520/7312809/4e060200-ea06-11e4-92f5-ca1a22635f12.png)
There's a typo on the wiki right now. Wool Boots in Dunby are said to require merchant rating level 2, however they are available for purchase at level one. This just changes the "MerchantRating" value for Wool Boots to be 1 instead of 2. If you go to the discussion page for the commerce page on the wiki, you'll see I started a thread to discuss this.

Attached image is the result.
